### PR TITLE
chore(build): bump Rust toolchain to 1.85.1 for edition-2024 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # BUILDPLATFORM is available inside Docker context. It contains the name of the host platform
 # See https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images
 # See https://jakewharton.com/cross-compiling-static-rust-binaries-in-docker-for-raspberry-pi/
-FROM --platform=$BUILDPLATFORM rust:1.68.1 as builder
+FROM --platform=$BUILDPLATFORM rust:1.85.1-bullseye as builder
 
 # TARGETPLATFORM is available inside the Docker context. It contains the name of the target platform
 # See https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # match with version in DockerFile
-channel = "1.65.0"
+channel = "1.85.1"


### PR DESCRIPTION
Unblocks the GHCR image build after PR #6.

## The problem

PR #6 (`chore(security): bump vulnerable Cargo.lock transitive deps`) merged 2026-05-18, but the follow-on `build_image.yml` run failed (run [26024464514](https://github.com/iotexproject/iotex-client-gateway/actions/runs/26024464514)) at the `cargo build` step:

```
error: failed to parse manifest at `/usr/local/cargo/registry/src/.../indexmap-2.14.0/Cargo.toml`
Caused by: failed to parse the `edition` key
Caused by: this version of Cargo is older than the `2024` edition,
           and only supports `2015`, `2018`, and `2021` editions.
```

`cargo update` in PR #6 pulled in `indexmap@2.14.0` (and likely other crates) that declare `edition = "2024"`. Edition 2024 was stabilised in Rust 1.85.0, but the build env was pinned to:

| File | Old version | Released |
|---|---|---|
| `Dockerfile` | `rust:1.68.1` | April 2023 |
| `rust-toolchain.toml` | `1.65.0` | November 2022 |

So the build dies during dependency parsing.

## Impact while broken

`ghcr.io/iotexproject/safe-gateway-web:iotex-stg` is still the Aug 2024 image. Both OVH staging (`ovh-vps7-safe-staging`) and OVH prod (`ovh-vps6-safe-prod`) pull this tag in their docker-compose stacks, so neither runtime has the security bumps from PR #6 — they're running ~21-month-old binary with the known-vulnerable transitive deps.

## The change

| File | From | To | Why |
|---|---|---|---|
| `Dockerfile` | `rust:1.68.1` | `rust:1.85.1-bullseye` | Minimum version that understands `edition = "2024"`. `-bullseye` keeps glibc compatible with the `debian:bullseye-slim` runtime stage (line 54). |
| `rust-toolchain.toml` | `1.65.0` | `1.85.1` | Match the Dockerfile, per the existing inline comment. |

Pinned to `1.85.1` (not `1.85` floating or `latest`) for reproducibility.

## Test plan

- This PR's `build_image.yml` should succeed where PR #6's didn't.
- Verify the new `ghcr.io/iotexproject/safe-gateway-web:iotex-stg` digest after merge, then plan a `docker compose pull && up -d` on `ovh-vps7-safe-staging` for a soak before letting `ovh-vps6-safe-prod` pull the same tag.

## Notes

- 20-minor-version Rust jump (1.65 → 1.85). Pure transitive-dep effort; this codebase's `Cargo.toml` MSRV isn't declared, but `safe-eth-py`-style crates have long since required 1.7x+. Worth eyeballing the build log for any new deprecation warnings.
- The Dockerfile uses lowercase `as` (line 6) which triggers a `FromAsCasing` lint warning. Not changed here — single-purpose PR. Can be cleaned up in a follow-up.