### PR TITLE
chore(build_image): add :sha-<short> tag to GHCR pushes

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY_URI_WEB }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=short
 
 
       - name: Build and push Docker image web
@@ -70,6 +75,11 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY_URI_NGINX }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=short
       - name: Build and push Docker image nginx
         id: build-and-push-nginx
         uses: docker/build-push-action@v4


### PR DESCRIPTION
Adds `type=sha,prefix=sha-,format=short` to `docker/metadata-action` for both image streams (`safe-*-web` and `safe-*-nginx`). Existing tag behavior preserved — this PR just adds the new tag stream.

## Why

The Safe wallet deploy pipeline now lives in `iotex-web-ops` (private). Prod consumes images by SHA-pinned tag (e.g. `image: ghcr.io/iotexproject/safe-…:sha-abc1234`) so deploys are immutable + reproducible. This PR adds the SHA tag that pinning will reference.

See `iotex-web-ops/safe-wallet/safe-migrate.md` → "OVH CI/CD architecture (target state)" for the full design. iotex-web-ops PR #56 wires the deploy side.

## What's tagged after this lands

| Trigger | Tags emitted |
|---|---|
| Push to `iotex-stg` | `:iotex-stg` + `:sha-<short>` |
| Push to `v*.*.*` tag | `:vX.Y.Z` + `:sha-<short>` |
| Open PR | `:pr-<n>` + `:sha-<short>` (image built, not pushed — `push: ${{ github.event_name != 'pull_request' }}`) |

`:latest` is not added by this PR — kept as "latest tagged release" per the existing convention (untouched since 2024 release tags).

## Test plan

- [ ] After merge, push to `iotex-stg` triggers `build_image.yml`. Confirm GHCR has both `:iotex-stg` and `:sha-<short>` for the new image.
- [ ] iotex-web-ops PR can then bump `image: …:iotex-stg` → `image: …:sha-<short>` in `ovh-vps{6,7}-safe-*/docker-compose.yml` to start using SHA pins.